### PR TITLE
chore: ignore @void-sdk/void in renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>Boshen/renovate"]
+  "extends": ["github>Boshen/renovate"],
+  "ignoreDeps": ["@void-sdk/void"]
 }


### PR DESCRIPTION
## Summary
- add a local Renovate `ignoreDeps` override for `@void-sdk/void`
- keep inheriting the shared `github>Boshen/renovate` preset

## Testing
- `node -e "JSON.parse(require('fs').readFileSync('.github/renovate.json','utf8'))"`
- `git diff --check`