### PR TITLE
ci: replace actions/checkout with taiki-e/checkout-action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         version: [latest, alpha]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
 
       - name: Setup Vite+ (${{ matrix.version }})
         uses: ./
@@ -36,7 +36,7 @@ jobs:
         version: [latest, alpha]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
 
       - name: Setup Vite+ (${{ matrix.version }}) with Node.js ${{ matrix.node-version }}
         uses: ./
@@ -65,7 +65,7 @@ jobs:
         version: [latest, alpha]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
 
       - name: Create test project with pnpm-lock.yaml
         run: |
@@ -96,7 +96,7 @@ jobs:
         version: [latest, alpha]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
 
       - name: Create test project with package-lock.json
         run: |
@@ -127,7 +127,7 @@ jobs:
         version: [latest, alpha]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
 
       - name: Create test project with yarn.lock
         run: |
@@ -159,7 +159,7 @@ jobs:
         lockfile: [bun.lock, bun.lockb]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
 
       - name: Create test project with ${{ matrix.lockfile }}
         run: |
@@ -191,7 +191,7 @@ jobs:
         version: [latest, alpha]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
 
       - name: Setup Vite+ (${{ matrix.version }})
         uses: ./
@@ -211,7 +211,7 @@ jobs:
         version: [latest, alpha]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
 
       - name: Create test project
         shell: bash
@@ -243,7 +243,7 @@ jobs:
         version: [latest, alpha]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
 
       - name: Setup Vite+ (${{ matrix.version }}) with registry-url
         uses: ./
@@ -277,7 +277,7 @@ jobs:
       - name: Install Alpine dependencies
         run: apk add --no-cache bash curl gcompat libstdc++
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
 
       - name: Setup Vite+ (${{ matrix.version }})
         uses: ./
@@ -295,7 +295,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
 
       - name: Setup Vite+ with cache
         uses: ./


### PR DESCRIPTION
## Summary
- replace `actions/checkout` with `taiki-e/checkout-action` pinned to `v1.4.2`

## Verification
- `actionlint`
