### PR TITLE
[codex] Document runtime-only setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,23 @@ steps:
       node-version: "lts"
 ```
 
+### Runtime Only
+
+Set `run-install: false` when a workflow only needs `vp` and the requested
+Node.js runtime, or when you want to run installation commands yourself. This
+keeps setup-vp from running `vp install` in the workspace and avoids creating
+project files in repositories that do not have a package manifest at that path.
+
+```yaml
+steps:
+  - uses: actions/checkout@v6
+  - uses: voidzero-dev/setup-vp@v1
+    with:
+      working-directory: docs
+      node-version: "lts"
+      run-install: false
+```
+
 ### With Node.js Version File
 
 ```yaml


### PR DESCRIPTION
## Summary

Documents the `run-install: false` path for workflows that only need `vp` and the requested Node.js runtime, or that want to run installation commands manually.

This gives users a clear setup-vp configuration for paths without a `package.json`, avoiding an automatic `vp install` in the workspace.

Related to #18.

## Validation

- `pnpm run check`
- `git diff --check`