### PR TITLE
[codex] Schedule the test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [main]
   merge_group:
+  schedule:
+    - cron: "17 3 * * *"
   workflow_dispatch:
     inputs:
       pr_version:


### PR DESCRIPTION
## Summary

Adds a daily scheduled trigger to the existing test workflow so setup-vp continues exercising the latest published Vite+ path even without repository pushes.

This is a small step toward the scheduled-regression coverage described in #12 while keeping the existing workflow structure unchanged.

Related to #12.

## Validation

- Parsed `.github/workflows/test.yml` with the `yaml` package
- `pnpm run check`
- `git diff --check`