### PR TITLE
chore: group all Vite+ packages in one Renovate PR

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,8 +9,9 @@
       "addLabels": ["needs-bundle-rebuild"]
     },
     {
-      "description": "vite-plus is the bundler; its updates can change dist/ output.",
-      "matchPackageNames": ["vite-plus"],
+      "description": "Group all Vite+ packages into a single PR; they are published together at the same version. vite-plus is the bundler, so its updates can change dist/ output.",
+      "groupName": "vite-plus",
+      "matchPackageNames": ["vite-plus", "@voidzero-dev/vite-plus-*"],
       "addLabels": ["needs-bundle-rebuild"]
     }
   ],


### PR DESCRIPTION
Group all Vite+ packages into a single Renovate PR instead of one PR per package.

`vite-plus` and the `@voidzero-dev/vite-plus-*` packages (including the `@voidzero-dev/vite-plus-core` catalog alias and the platform binaries) are always published together at the same version, so they should update together.

- Add a `groupName: "vite-plus"` rule matching `vite-plus` and `@voidzero-dev/vite-plus-*`.
- Keep the `needs-bundle-rebuild` label on the grouped PR so the auto-rebuild workflow still refreshes `dist/`.

Refs #105