### PR TITLE
fix: stop defaulting setup-ref/setupRef to the frozen v1 tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,15 +478,15 @@ test:
 
 ### GitLab Inputs
 
-| Input               | Description                                                                                                                                                     | Default  |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `version`           | Version of Vite+ to install                                                                                                                                     | `latest` |
-| `working-directory` | Project directory used for relative paths and default `vp install` execution                                                                                    | `.`      |
-| `run-install`       | String input for `vp install` after setup. Use `"true"`/`"false"` or a YAML object/list with `cwd`/`args`                                                       | `true`   |
-| `sfw`               | Wrap `vp install` with [Socket Firewall Free](https://docs.socket.dev/docs/socket-firewall-free)                                                                | `false`  |
-| `registry-url`      | Optional registry URL to write to a temporary `.npmrc`                                                                                                          |          |
-| `scope`             | Optional scope for authenticating against scoped registries                                                                                                     |          |
-| `setup-ref`         | setup-vp ref used to download the GitLab bootstrap and compiled runtime. Always set it to the same tag as the remote URL; the default `v1` is frozen at v1.15.0 | `v1`     |
+| Input               | Description                                                                                                                                                                                 | Default   |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
+| `version`           | Version of Vite+ to install                                                                                                                                                                 | `latest`  |
+| `working-directory` | Project directory used for relative paths and default `vp install` execution                                                                                                                | `.`       |
+| `run-install`       | String input for `vp install` after setup. Use `"true"`/`"false"` or a YAML object/list with `cwd`/`args`                                                                                   | `true`    |
+| `sfw`               | Wrap `vp install` with [Socket Firewall Free](https://docs.socket.dev/docs/socket-firewall-free)                                                                                            | `false`   |
+| `registry-url`      | Optional registry URL to write to a temporary `.npmrc`                                                                                                                                      |           |
+| `scope`             | Optional scope for authenticating against scoped registries                                                                                                                                 |           |
+| `setup-ref`         | setup-vp ref used to download the GitLab bootstrap and compiled runtime. Always set it to the same tag as the remote URL; the default is the latest release when the template was published | `v1.16.0` |
 
 ### GitLab Notes
 
@@ -538,18 +538,18 @@ Pin `ref` and `setupRef` to the same exact tag or commit SHA. Do not use the `v1
 
 ### Azure Parameters
 
-| Parameter             | Default  | Description                                                                                                                                       |
-| --------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `version`             | `latest` | Vite+ version/dist-tag passed to the official installer.                                                                                          |
-| `workingDirectory`    | `.`      | Project directory for lock detection and default `vp install`.                                                                                    |
-| `runInstall`          | `true`   | Run `vp install`; accepts boolean or object/list with `cwd` and `args`.                                                                           |
-| `sfw`                 | `false`  | Wrap `vp install` with Socket Firewall Free.                                                                                                      |
-| `registryUrl`         |          | Optional registry URL for a temporary `.npmrc`.                                                                                                   |
-| `scope`               |          | Optional npm registry scope.                                                                                                                      |
-| `setupRef`            | `v1`     | Ref used to download bootstrap scripts and `dist/azure/index.mjs`. Always set it to the same tag as `ref`; the default `v1` is frozen at v1.15.0. |
-| `nodeVersion`         | `24.x`   | Passed to `UseNode@1`; an empty string skips Node setup.                                                                                          |
-| `cache`               | `false`  | Enable Azure `Cache@2` around the package-manager cache directory.                                                                                |
-| `cacheDependencyPath` |          | Explicit lock file relative to `workingDirectory`; otherwise auto-detect.                                                                         |
+| Parameter             | Default   | Description                                                                                                                                                                   |
+| --------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `version`             | `latest`  | Vite+ version/dist-tag passed to the official installer.                                                                                                                      |
+| `workingDirectory`    | `.`       | Project directory for lock detection and default `vp install`.                                                                                                                |
+| `runInstall`          | `true`    | Run `vp install`; accepts boolean or object/list with `cwd` and `args`.                                                                                                       |
+| `sfw`                 | `false`   | Wrap `vp install` with Socket Firewall Free.                                                                                                                                  |
+| `registryUrl`         |           | Optional registry URL for a temporary `.npmrc`.                                                                                                                               |
+| `scope`               |           | Optional npm registry scope.                                                                                                                                                  |
+| `setupRef`            | `v1.16.0` | Ref used to download bootstrap scripts and `dist/azure/index.mjs`. Always set it to the same tag as `ref`; the default is the latest release when the template was published. |
+| `nodeVersion`         | `24.x`    | Passed to `UseNode@1`; an empty string skips Node setup.                                                                                                                      |
+| `cache`               | `false`   | Enable Azure `Cache@2` around the package-manager cache directory.                                                                                                            |
+| `cacheDependencyPath` |           | Explicit lock file relative to `workingDirectory`; otherwise auto-detect.                                                                                                     |
 
 ### Azure Job Variables
 
@@ -632,7 +632,7 @@ Releases are published as git tags; there is no npm package, but the `package.js
 
 To cut a release:
 
-1. Open and merge a PR that bumps the `version` in `package.json` and the version tag in the README examples to the upcoming release.
+1. Open and merge a PR that bumps the upcoming version in `package.json`, the README examples, and the `setup-ref` / `setupRef` defaults in `gitlab/setup-vp.yml` and `azure/setup-vp.yml` (with the matching assertion in `src/azure/template.test.ts`).
 
 2. Update `main` and confirm `dist/index.mjs` is in sync (the working tree must stay clean after building):
 

--- a/azure/setup-vp.yml
+++ b/azure/setup-vp.yml
@@ -19,7 +19,7 @@ parameters:
     default: ""
   - name: setupRef
     type: string
-    default: v1
+    default: v1.16.0
   - name: nodeVersion
     type: string
     default: 24.x

--- a/gitlab/setup-vp.yml
+++ b/gitlab/setup-vp.yml
@@ -20,8 +20,8 @@ spec:
       description: "Optional scope for authenticating against scoped registries."
       default: ""
     setup-ref:
-      description: "setup-vp ref used to download the GitLab bootstrap and compiled runtime. Pin this to the same tag or commit as the remote template for strict reproducibility."
-      default: "v1"
+      description: "setup-vp ref used to download the GitLab bootstrap and compiled runtime. Pin this to the same tag or commit as the remote template; the default is the latest release when this template was published."
+      default: "v1.16.0"
 ---
 .setup-vp-bootstrap:
   before_script:
@@ -48,7 +48,7 @@ spec:
       export SETUP_VP_SFW="${SETUP_VP_SFW:-false}"
       export SETUP_VP_REGISTRY_URL="${SETUP_VP_REGISTRY_URL:-}"
       export SETUP_VP_SCOPE="${SETUP_VP_SCOPE:-}"
-      export SETUP_VP_SETUP_REF="${SETUP_VP_SETUP_REF:-v1}"
+      export SETUP_VP_SETUP_REF="${SETUP_VP_SETUP_REF:-v1.16.0}"
 
       setup_vp_bootstrap_tmp="$(mktemp "${TMPDIR:-/tmp}/setup-vp-gitlab-bootstrap.XXXXXX")"
       setup_vp_env_tmp="$(mktemp "${TMPDIR:-/tmp}/setup-vp-gitlab-env.XXXXXX")"

--- a/src/azure/template.test.ts
+++ b/src/azure/template.test.ts
@@ -22,7 +22,7 @@ describe("azure/setup-vp.yml", () => {
     expect(byName.sfw).toMatchObject({ type: "boolean", default: false });
     expect(byName.registryUrl).toMatchObject({ type: "string", default: "" });
     expect(byName.scope).toMatchObject({ type: "string", default: "" });
-    expect(byName.setupRef).toMatchObject({ type: "string", default: "v1" });
+    expect(byName.setupRef).toMatchObject({ type: "string", default: "v1.16.0" });
     expect(byName.nodeVersion).toMatchObject({ type: "string", default: "24.x" });
     expect(byName.cache).toMatchObject({ type: "boolean", default: false });
     expect(byName.cacheDependencyPath).toMatchObject({ type: "string", default: "" });


### PR DESCRIPTION
Follow-up to #116 (now merged).

An unpinned `setup-ref` (GitLab) or `setupRef` (Azure) downloaded the compiled runtime from the moving `v1` tag, which is now frozen at v1.15.0, so unpinned includes silently ran a stale v1.15.0 runtime.

- Default `setup-ref` / `setupRef` (input default and bash env fallback) to `v1.16.0`, the latest release
- Update the README input tables and the release checklist: the release PR now also bumps these defaults, so from v1.17.0 on the shipped template downloads the runtime of its own release
- Update the `src/azure/template.test.ts` assertion

The README examples keep the explicit `setup-ref` pin, which is still the recommended setup and the only correct one for v1.16.0 itself (its shipped template default is the frozen `v1`).
