### PR TITLE
chore: release v1.16.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -642,7 +642,7 @@ To cut a release:
    git status --short   # must be empty
    ```
 
-3. Create the new annotated version tag and push it. For example, with `v1.16.0` as the latest release, the next fix release is `v1.16.1`:
+3. Create the new annotated version tag and push it. For example:
 
    ```bash
    git tag -a v1.16.1 -m "v1.16.1"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ GitHub Action, GitLab CI/CD remote template, and Azure Pipelines step template t
 Reference this action with an exact release tag, or a commit SHA:
 
 ```yaml
-- uses: voidzero-dev/setup-vp@v1.16.0
+- uses: voidzero-dev/setup-vp@v1.16.1
 ```
 
 Releases are listed on the [tags page](https://github.com/voidzero-dev/setup-vp/tags). [Renovate](https://docs.renovatebot.com/) and Dependabot can keep a pinned tag up to date.
@@ -33,7 +33,7 @@ Releases are listed on the [tags page](https://github.com/voidzero-dev/setup-vp/
 ```yaml
 steps:
   - uses: actions/checkout@v6
-  - uses: voidzero-dev/setup-vp@v1.16.0
+  - uses: voidzero-dev/setup-vp@v1.16.1
 ```
 
 ### With Node.js Version
@@ -41,7 +41,7 @@ steps:
 ```yaml
 steps:
   - uses: actions/checkout@v6
-  - uses: voidzero-dev/setup-vp@v1.16.0
+  - uses: voidzero-dev/setup-vp@v1.16.1
     with:
       node-version: "lts"
 ```
@@ -51,7 +51,7 @@ steps:
 ```yaml
 steps:
   - uses: actions/checkout@v6
-  - uses: voidzero-dev/setup-vp@v1.16.0
+  - uses: voidzero-dev/setup-vp@v1.16.1
     with:
       node-version-file: ".node-version"
 ```
@@ -61,7 +61,7 @@ steps:
 ```yaml
 steps:
   - uses: actions/checkout@v6
-  - uses: voidzero-dev/setup-vp@v1.16.0
+  - uses: voidzero-dev/setup-vp@v1.16.1
     with:
       working-directory: web
       node-version-file: ".nvmrc"
@@ -74,7 +74,7 @@ steps:
 ```yaml
 steps:
   - uses: actions/checkout@v6
-  - uses: voidzero-dev/setup-vp@v1.16.0
+  - uses: voidzero-dev/setup-vp@v1.16.1
     with:
       node-version: "lts"
       cache: true
@@ -86,7 +86,7 @@ steps:
 ```yaml
 steps:
   - uses: actions/checkout@v6
-  - uses: voidzero-dev/setup-vp@v1.16.0
+  - uses: voidzero-dev/setup-vp@v1.16.1
     with:
       version: "1.2.3"
       node-version: "lts"
@@ -110,7 +110,7 @@ to `latest` only when nothing pins a resolvable version. So a project that pins
 ```yaml
 steps:
   - uses: actions/checkout@v6
-  - uses: voidzero-dev/setup-vp@v1.16.0
+  - uses: voidzero-dev/setup-vp@v1.16.1
     with:
       cache: true
 ```
@@ -123,7 +123,7 @@ worth watching for, since it means the pinned version was not applied:
 ```yaml
 steps:
   - uses: actions/checkout@v6
-  - uses: voidzero-dev/setup-vp@v1.16.0
+  - uses: voidzero-dev/setup-vp@v1.16.1
     with:
       version-file: package.json
       cache: true
@@ -183,7 +183,7 @@ action warns and falls back to `latest`. (Auto-detection instead resolves a
 ```yaml
 steps:
   - uses: actions/checkout@v6
-  - uses: voidzero-dev/setup-vp@v1.16.0
+  - uses: voidzero-dev/setup-vp@v1.16.1
     with:
       node-version: "lts"
       cache: true
@@ -208,7 +208,7 @@ minimal:
 
 steps:
   - uses: actions/checkout@v6
-  - uses: voidzero-dev/setup-vp@v1.16.0
+  - uses: voidzero-dev/setup-vp@v1.16.1
     with:
       node-version: "lts"
     env:
@@ -225,7 +225,7 @@ read the repo `.npmrc` per its own config resolution):
 ```yaml
 steps:
   - uses: actions/checkout@v6
-  - uses: voidzero-dev/setup-vp@v1.16.0
+  - uses: voidzero-dev/setup-vp@v1.16.1
     with:
       node-version: "lts"
       registry-url: "https://npm.pkg.github.com"
@@ -243,7 +243,7 @@ Set `sfw: true` to wrap `vp install` with [Socket Firewall Free](https://docs.so
 ```yaml
 steps:
   - uses: actions/checkout@v6
-  - uses: voidzero-dev/setup-vp@v1.16.0
+  - uses: voidzero-dev/setup-vp@v1.16.1
     with:
       sfw: true
       run-install: true
@@ -264,7 +264,7 @@ steps:
   - uses: socketdev/action@<sha>
     with:
       mode: firewall-free
-  - uses: voidzero-dev/setup-vp@v1.16.0
+  - uses: voidzero-dev/setup-vp@v1.16.1
     with:
       sfw: true
       run-install: true
@@ -288,7 +288,7 @@ jobs:
     steps:
       - run: apk add --no-cache bash curl gcompat libstdc++
       - uses: actions/checkout@v6
-      - uses: voidzero-dev/setup-vp@v1.16.0
+      - uses: voidzero-dev/setup-vp@v1.16.1
 ```
 
 ### Matrix Testing with Multiple Node.js Versions
@@ -302,7 +302,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: voidzero-dev/setup-vp@v1.16.0
+      - uses: voidzero-dev/setup-vp@v1.16.1
         with:
           node-version: ${{ matrix.node-version }}
           cache: true
@@ -366,9 +366,9 @@ Use an exact release tag in the `include:remote` URL, and pin `setup-ref` to the
 
 ```yaml
 include:
-  - remote: "https://raw.githubusercontent.com/voidzero-dev/setup-vp/v1.16.0/gitlab/setup-vp.yml"
+  - remote: "https://raw.githubusercontent.com/voidzero-dev/setup-vp/v1.16.1/gitlab/setup-vp.yml"
     inputs:
-      setup-ref: "v1.16.0"
+      setup-ref: "v1.16.1"
 
 test:
   extends: .setup-vp
@@ -381,9 +381,9 @@ test:
 
 ```yaml
 include:
-  - remote: "https://raw.githubusercontent.com/voidzero-dev/setup-vp/v1.16.0/gitlab/setup-vp.yml"
+  - remote: "https://raw.githubusercontent.com/voidzero-dev/setup-vp/v1.16.1/gitlab/setup-vp.yml"
     inputs:
-      setup-ref: "v1.16.0"
+      setup-ref: "v1.16.1"
       version: "latest"
       working-directory: "web"
       run-install: "true"
@@ -401,14 +401,14 @@ GitLab replaces array keywords such as `before_script` when a job uses `extends`
 
 ```yaml
 include:
-  - remote: "https://raw.githubusercontent.com/voidzero-dev/setup-vp/v1.16.0/gitlab/setup-vp.yml"
+  - remote: "https://raw.githubusercontent.com/voidzero-dev/setup-vp/v1.16.1/gitlab/setup-vp.yml"
 
 test:
   image: node:24
   variables:
     SETUP_VP_VERSION: "latest"
     SETUP_VP_RUN_INSTALL: "true"
-    SETUP_VP_SETUP_REF: "v1.16.0"
+    SETUP_VP_SETUP_REF: "v1.16.1"
   before_script:
     - !reference [.setup-vp-bootstrap, before_script]
     - npm config set //registry.example.com/:_authToken "$NODE_AUTH_TOKEN"
@@ -423,9 +423,9 @@ Use the same pattern when the project has `default:before_script`; put the share
 
 ```yaml
 include:
-  - remote: "https://raw.githubusercontent.com/voidzero-dev/setup-vp/v1.16.0/gitlab/setup-vp.yml"
+  - remote: "https://raw.githubusercontent.com/voidzero-dev/setup-vp/v1.16.1/gitlab/setup-vp.yml"
     inputs:
-      setup-ref: "v1.16.0"
+      setup-ref: "v1.16.1"
       run-install: |
         - cwd: ./packages/app
           args: ['--frozen-lockfile']
@@ -442,9 +442,9 @@ test:
 
 ```yaml
 include:
-  - remote: "https://raw.githubusercontent.com/voidzero-dev/setup-vp/v1.16.0/gitlab/setup-vp.yml"
+  - remote: "https://raw.githubusercontent.com/voidzero-dev/setup-vp/v1.16.1/gitlab/setup-vp.yml"
     inputs:
-      setup-ref: "v1.16.0"
+      setup-ref: "v1.16.1"
       sfw: true
       run-install: "true"
 
@@ -461,9 +461,9 @@ Pass `NODE_AUTH_TOKEN` as a GitLab CI/CD variable and set `registry-url` when th
 
 ```yaml
 include:
-  - remote: "https://raw.githubusercontent.com/voidzero-dev/setup-vp/v1.16.0/gitlab/setup-vp.yml"
+  - remote: "https://raw.githubusercontent.com/voidzero-dev/setup-vp/v1.16.1/gitlab/setup-vp.yml"
     inputs:
-      setup-ref: "v1.16.0"
+      setup-ref: "v1.16.1"
       registry-url: "https://npm.pkg.github.com"
       scope: "@myorg"
 
@@ -486,11 +486,11 @@ test:
 | `sfw`               | Wrap `vp install` with [Socket Firewall Free](https://docs.socket.dev/docs/socket-firewall-free)                                                                                            | `false`   |
 | `registry-url`      | Optional registry URL to write to a temporary `.npmrc`                                                                                                                                      |           |
 | `scope`             | Optional scope for authenticating against scoped registries                                                                                                                                 |           |
-| `setup-ref`         | setup-vp ref used to download the GitLab bootstrap and compiled runtime. Always set it to the same tag as the remote URL; the default is the latest release when the template was published | `v1.16.0` |
+| `setup-ref`         | setup-vp ref used to download the GitLab bootstrap and compiled runtime. Always set it to the same tag as the remote URL; the default is the latest release when the template was published | `v1.16.1` |
 
 ### GitLab Notes
 
-- Use an exact release tag such as `v1.16.0` in the remote URL. Do not use `main` (mutable) or `v1` (frozen at v1.15.0, no longer updated).
+- Use an exact release tag such as `v1.16.1` in the remote URL. Do not use `main` (mutable) or `v1` (frozen at v1.15.0, no longer updated).
 - Always pin `setup-ref` to the same tag or commit SHA as the remote URL, so the compiled runtime matches the included template.
 - Quote GitLab string inputs such as `run-install: "false"`; unquoted booleans are rejected by GitLab before the setup runtime can parse them.
 - GitLab 17.9+ users can add `integrity` to pin the remote file hash.
@@ -516,7 +516,7 @@ resources:
       type: github
       endpoint: github
       name: voidzero-dev/setup-vp
-      ref: refs/tags/v1.16.0
+      ref: refs/tags/v1.16.1
 
 pool:
   vmImage: ubuntu-latest
@@ -526,7 +526,7 @@ steps:
 
   - template: azure/setup-vp.yml@setupVp
     parameters:
-      setupRef: v1.16.0
+      setupRef: v1.16.1
       nodeVersion: 24.x
       cache: true
       runInstall: true
@@ -546,7 +546,7 @@ Pin `ref` and `setupRef` to the same exact tag or commit SHA. Do not use the `v1
 | `sfw`                 | `false`   | Wrap `vp install` with Socket Firewall Free.                                                                                                                                  |
 | `registryUrl`         |           | Optional registry URL for a temporary `.npmrc`.                                                                                                                               |
 | `scope`               |           | Optional npm registry scope.                                                                                                                                                  |
-| `setupRef`            | `v1.16.0` | Ref used to download bootstrap scripts and `dist/azure/index.mjs`. Always set it to the same tag as `ref`; the default is the latest release when the template was published. |
+| `setupRef`            | `v1.16.1` | Ref used to download bootstrap scripts and `dist/azure/index.mjs`. Always set it to the same tag as `ref`; the default is the latest release when the template was published. |
 | `nodeVersion`         | `24.x`    | Passed to `UseNode@1`; an empty string skips Node setup.                                                                                                                      |
 | `cache`               | `false`   | Enable Azure `Cache@2` around the package-manager cache directory.                                                                                                            |
 | `cacheDependencyPath` |           | Explicit lock file relative to `workingDirectory`; otherwise auto-detect.                                                                                                     |
@@ -584,7 +584,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: voidzero-dev/setup-vp@v1.16.0
+      - uses: voidzero-dev/setup-vp@v1.16.1
         with:
           node-version: "lts"
           cache: true
@@ -628,7 +628,7 @@ vp install
 
 ### Releasing
 
-Releases are published as git tags; there is no npm package, but the `package.json` version tracks the latest release. Consumers pin an exact version tag such as `voidzero-dev/setup-vp@v1.16.0` or a commit SHA. The `v1` major tag is frozen at v1.15.0 and is never moved (an org-level ruleset rejects tag force-pushes).
+Releases are published as git tags; there is no npm package, but the `package.json` version tracks the latest release. Consumers pin an exact version tag such as `voidzero-dev/setup-vp@v1.16.1` or a commit SHA. The `v1` major tag is frozen at v1.15.0 and is never moved (an org-level ruleset rejects tag force-pushes).
 
 To cut a release:
 
@@ -642,11 +642,11 @@ To cut a release:
    git status --short   # must be empty
    ```
 
-3. Create the new annotated version tag, bumping the minor from the latest release, and push it. For example, with `v1.15.0` as the latest release, the next tag is `v1.16.0`:
+3. Create the new annotated version tag and push it. For example, with `v1.16.0` as the latest release, the next fix release is `v1.16.1`:
 
    ```bash
-   git tag -a v1.16.0 -m "v1.16.0"
-   git push origin v1.16.0
+   git tag -a v1.16.1 -m "v1.16.1"
+   git push origin v1.16.1
    ```
 
 ## Feedback

--- a/azure/setup-vp.yml
+++ b/azure/setup-vp.yml
@@ -19,7 +19,7 @@ parameters:
     default: ""
   - name: setupRef
     type: string
-    default: v1.16.0
+    default: v1.16.1
   - name: nodeVersion
     type: string
     default: 24.x

--- a/gitlab/setup-vp.yml
+++ b/gitlab/setup-vp.yml
@@ -21,7 +21,7 @@ spec:
       default: ""
     setup-ref:
       description: "setup-vp ref used to download the GitLab bootstrap and compiled runtime. Pin this to the same tag or commit as the remote template; the default is the latest release when this template was published."
-      default: "v1.16.0"
+      default: "v1.16.1"
 ---
 .setup-vp-bootstrap:
   before_script:
@@ -48,7 +48,7 @@ spec:
       export SETUP_VP_SFW="${SETUP_VP_SFW:-false}"
       export SETUP_VP_REGISTRY_URL="${SETUP_VP_REGISTRY_URL:-}"
       export SETUP_VP_SCOPE="${SETUP_VP_SCOPE:-}"
-      export SETUP_VP_SETUP_REF="${SETUP_VP_SETUP_REF:-v1.16.0}"
+      export SETUP_VP_SETUP_REF="${SETUP_VP_SETUP_REF:-v1.16.1}"
 
       setup_vp_bootstrap_tmp="$(mktemp "${TMPDIR:-/tmp}/setup-vp-gitlab-bootstrap.XXXXXX")"
       setup_vp_env_tmp="$(mktemp "${TMPDIR:-/tmp}/setup-vp-gitlab-env.XXXXXX")"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-vp",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/azure/template.test.ts
+++ b/src/azure/template.test.ts
@@ -22,7 +22,7 @@ describe("azure/setup-vp.yml", () => {
     expect(byName.sfw).toMatchObject({ type: "boolean", default: false });
     expect(byName.registryUrl).toMatchObject({ type: "string", default: "" });
     expect(byName.scope).toMatchObject({ type: "string", default: "" });
-    expect(byName.setupRef).toMatchObject({ type: "string", default: "v1.16.0" });
+    expect(byName.setupRef).toMatchObject({ type: "string", default: "v1.16.1" });
     expect(byName.nodeVersion).toMatchObject({ type: "string", default: "24.x" });
     expect(byName.cache).toMatchObject({ type: "boolean", default: false });
     expect(byName.cacheDependencyPath).toMatchObject({ type: "string", default: "" });


### PR DESCRIPTION
Bump the version to v1.16.1 in package.json, the README examples, and the setup-ref / setupRef defaults in the GitLab and Azure templates.

Changes since v1.16.0:

- fix: stop defaulting setup-ref/setupRef to the frozen v1 tag (#117)
- docs: use exact version tags instead of the moving v1 tag (#116)

After merge, tag the merge commit as v1.16.1 and push the tag.