### PR TITLE
chore: align Renovate release age for the whole vite-plus group

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,10 +9,12 @@
       "addLabels": ["needs-bundle-rebuild"]
     },
     {
-      "description": "Group all Vite+ packages into a single PR; they are published together at the same version. vite-plus is the bundler, so its updates can change dist/ output.",
+      "description": "Group all Vite+ packages into a single PR; they are published together at the same version. vite-plus is the bundler, so its updates can change dist/ output. minimumReleaseAge and schedule keep @voidzero-dev/vite-plus-* (the vite catalog alias) on the same policy as vite-plus; the preset's generic npm rule would otherwise hold the alias behind a 3-day age gate and a Monday schedule.",
       "groupName": "vite-plus",
       "matchPackageNames": ["vite-plus", "@voidzero-dev/vite-plus-*"],
-      "addLabels": ["needs-bundle-rebuild"]
+      "addLabels": ["needs-bundle-rebuild"],
+      "minimumReleaseAge": "0 days",
+      "schedule": ["at any time"]
     }
   ],
   "customManagers": [


### PR DESCRIPTION
Renovate PR #119 bumped only the `vite-plus` catalog entry and left the `vite` alias at `@voidzero-dev/vite-plus-core@0.2.7`. The alias resolves to a different package name, so it matches the preset's generic npm rule (3-day `minimumReleaseAge`, Monday schedule) instead of the vite+ rule (0 days, any time). Both 0.2.8 packages were published together on Aug 5, but only `vite-plus` was eligible when Renovate ran 4 hours later.

Set `minimumReleaseAge` and `schedule` on the existing group rule so every `@voidzero-dev/vite-plus-*` package follows the same policy and one release lands as one grouped update.

After merging, a Renovate run should add the `vite` alias bump to #119.