### PR TITLE
docs: clarify automatic Node.js resolution

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,6 +126,39 @@ jobs:
             echo "$ACTUAL" | grep -q "^v${{ matrix.node-version }}\." || (echo "Expected Node.js v${{ matrix.node-version }}.x but got $ACTUAL" && exit 1)
           fi
 
+  # Reproduces https://github.com/voidzero-dev/setup-vp/issues/128: with no
+  # explicit Node.js input, the managed `node` shim should use Vite+'s normal
+  # project resolution and honor package.json#devEngines.runtime.
+  test-auto-node-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
+
+      - name: Create project with devEngines.runtime
+        shell: bash
+        run: |
+          DIR="${RUNNER_TEMP//\\//}/test-project"
+          mkdir -p "$DIR"
+          echo '{"name":"test-project","private":true,"devEngines":{"runtime":{"name":"node","version":"22.18.0"}}}' > "$DIR/package.json"
+
+      - name: Setup Vite+ without a Node.js input
+        uses: ./
+        with:
+          working-directory: ${{ runner.temp }}/test-project
+          run-install: false
+          cache: false
+
+      - name: Verify project Node.js version
+        working-directory: ${{ runner.temp }}/test-project
+        shell: bash
+        run: |
+          ACTUAL=$(node --version)
+          echo "Node.js version: $ACTUAL"
+          if [ "$ACTUAL" != "v22.18.0" ]; then
+            echo "::error::expected Node.js v22.18.0 from devEngines.runtime, got $ACTUAL"
+            exit 1
+          fi
+
   # End-to-end check of node-manager: false. The installer must skip
   # node/npm/npx/corepack shim creation (VP_NODE_MANAGER=no) and the action
   # must run `vp env off`, so vp commands resolve the Node.js already on the

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ jobs:
 | ----------------------- | ----------------------------------------------------------------------------------------------------------- | -------- | ---------------- |
 | `version`               | Version of Vite+ to install. Takes precedence over `version-file`                                           | No       | auto / `latest`  |
 | `version-file`          | Path to a file to resolve the Vite+ version from (`package.json`, `pnpm-workspace.yaml`, or `.yarnrc.yml`)  | No       |                  |
-| `node-version`          | Node.js version to install via `vp env use`                                                                 | No       | Latest LTS       |
+| `node-version`          | Node.js version to install via `vp env use`                                                                 | No       | Vite+ resolution |
 | `node-version-file`     | Path to file containing Node.js version (`.nvmrc`, `.node-version`, `.tool-versions`, `package.json`)       | No       |                  |
 | `node-manager`          | Control Vite+'s Node.js manager: `false` keeps the runner's Node.js, `true` force-enables the managed one   | No       | Auto (on for CI) |
 | `working-directory`     | Project directory used for relative paths, lockfile auto-detection, environment checks, and default install | No       | Workspace root   |
@@ -344,6 +344,8 @@ jobs:
 | `scope`                 | Optional scope for scoped registries. Falls back to repo owner for GitHub Packages                          | No       |                  |
 
 When `working-directory` is set, relative `run-install.cwd`, `node-version-file`, `version-file`, and `cache-dependency-path` values are resolved from that directory.
+
+Omitting both `node-version` and `node-version-file` leaves the session without an override. With the Vite+ Node.js manager enabled, its shims search the current directory and its parents for `.node-version`, `package.json#devEngines.runtime`, `package.json#engines.node`, and `.nvmrc`, in that order. If the project does not declare a version, Vite+ uses its global default and then latest LTS.
 
 `node-manager: false` skips Node.js shim creation and runs `vp env off`, so `vp` commands prefer the Node.js already on `PATH`. It cannot be combined with `node-version` or `node-version-file`.
 

--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ jobs:
 
 When `working-directory` is set, relative `run-install.cwd`, `node-version-file`, `version-file`, and `cache-dependency-path` values are resolved from that directory.
 
-Omitting both `node-version` and `node-version-file` leaves the session without an override. With the Vite+ Node.js manager enabled, its shims search the current directory and its parents for `.node-version`, `package.json#devEngines.runtime`, `package.json#engines.node`, and `.nvmrc`, in that order. If the project does not declare a version, Vite+ uses its global default and then latest LTS.
+Omitting both `node-version` and `node-version-file` leaves the session without an override. With the Vite+ Node.js manager enabled, its shims search the current directory and its parents for `.node-version`, `package.json#devEngines.runtime`, `package.json#engines.node`, and `.nvmrc`, in that order. If the project does not declare a version, Vite+ uses the user-level default. Set this default with `vp env default <version>`. Vite+ stores this setting under `VP_HOME` (`~/.vite-plus` by default). If no user-level default exists, Vite+ uses the latest LTS release.
 
 `node-manager: false` skips Node.js shim creation and runs `vp env off`, so `vp` commands prefer the Node.js already on `PATH`. It cannot be combined with `node-version` or `node-version-file`.
 

--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ jobs:
 
 When `working-directory` is set, relative `run-install.cwd`, `node-version-file`, `version-file`, and `cache-dependency-path` values are resolved from that directory.
 
-Omitting both `node-version` and `node-version-file` leaves the session without an override. With the Vite+ Node.js manager enabled, its shims search the current directory and its parents for `.node-version`, `package.json#devEngines.runtime`, `package.json#engines.node`, and `.nvmrc`, in that order. If the project does not declare a version, Vite+ uses the user-level default. Set this default with `vp env default <version>`. Vite+ stores this setting under `VP_HOME` (`~/.vite-plus` by default). If no user-level default exists, Vite+ uses the latest LTS release.
+Omitting both `node-version` and `node-version-file` leaves the session without an override. With the Vite+ Node.js manager enabled, its shims search the current directory and its parents for `.node-version`, `package.json#devEngines.runtime`, `package.json#engines.node`, and `.nvmrc`, in that order. If the project does not declare a version, Vite+ uses the user-level default. Set this default with `vp env default <version>`. If no user-level default exists, Vite+ uses the latest LTS release.
 
 `node-manager: false` skips Node.js shim creation and runs `vp env off`, so `vp` commands prefer the Node.js already on `PATH`. It cannot be combined with `node-version` or `node-version-file`.
 

--- a/README.md
+++ b/README.md
@@ -347,6 +347,8 @@ When `working-directory` is set, relative `run-install.cwd`, `node-version-file`
 
 Omitting both `node-version` and `node-version-file` leaves the session without an override. With the Vite+ Node.js manager enabled, its shims search the current directory and its parents for `.node-version`, `package.json#devEngines.runtime`, `package.json#engines.node`, and `.nvmrc`, in that order. If the project does not declare a version, Vite+ uses the user-level default. Set this default with `vp env default <version>`. If no user-level default exists, Vite+ uses the latest LTS release.
 
+`working-directory` applies to the action. Each later workflow step keeps its own working directory. Vite+ searches for Node.js version sources from each command's current working directory. For a subproject, set `working-directory` on the step that runs `node` or `vp`.
+
 `node-manager: false` skips Node.js shim creation and runs `vp env off`, so `vp` commands prefer the Node.js already on `PATH`. It cannot be combined with `node-version` or `node-version-file`.
 
 ## Outputs

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
     required: false
     default: "false"
   node-version:
-    description: "Node.js version to install via `vp env use`. Omit this input and node-version-file to let Vite+ resolve the version from the project, then its global default, then latest LTS."
+    description: "Node.js version to install via `vp env use`. Omit this input and node-version-file to let Vite+ resolve the version. `vp env default <version>` sets the user-level default. Vite+ checks the project, this default, and then the latest LTS release."
     required: false
   node-version-file:
     description: "Path to file containing the Node.js version spec (.nvmrc, .node-version, .tool-versions, package.json). Ignored when node-version is specified."

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
     required: false
     default: "false"
   node-version:
-    description: "Node.js version to install via `vp env use`. Defaults to Node.js latest LTS version."
+    description: "Node.js version to install via `vp env use`. Omit this input and node-version-file to let Vite+ resolve the version from the project, then its global default, then latest LTS."
     required: false
   node-version-file:
     description: "Path to file containing the Node.js version spec (.nvmrc, .node-version, .tool-versions, package.json). Ignored when node-version is specified."


### PR DESCRIPTION
We updated `README.md` and `action.yml` to describe Vite+ Node.js version selection. The input table now shows `Vite+ resolution` as the `node-version` default.

If users omit `node-version` and `node-version-file`, Vite+ resolves the version from the project. It checks these sources in order:

1. `.node-version`
2. `package.json#devEngines.runtime`
3. `package.json#engines.node`
4. `.nvmrc`

Vite+ uses the user-level default if no project source exists. Set this default with `vp env default <version>`. Vite+ uses the latest LTS release if no user-level default exists.

We added a CI test for `devEngines.runtime`. The test resolves Node.js `v22.18.0` without an explicit Node.js input.

We changed documentation and tests. We kept the action runtime unchanged.

Closes #128