### PR TITLE
feat: report GitLab E2E results in PR comments

### DIFF
--- a/.github/workflows/gitlab-e2e.yml
+++ b/.github/workflows/gitlab-e2e.yml
@@ -41,6 +41,12 @@ jobs:
        github.event.workflow_run.head_repository.full_name != github.repository)
     runs-on: ubuntu-latest
     timeout-minutes: 35
+    outputs:
+      pr_number: ${{ steps.parameters.outputs.pr_number }}
+      setup_vp_ref: ${{ steps.parameters.outputs.setup_vp_ref }}
+      suite: ${{ steps.parameters.outputs.suite }}
+      vite_plus_version: ${{ steps.parameters.outputs.vite_plus_version }}
+      pipeline_url: ${{ steps.trigger.outputs.pipeline_url }}
     # Keep this privileged job API-only: no PR checkout, artifacts, or caches.
     steps:
       - name: Resolve test parameters
@@ -70,6 +76,7 @@ jobs:
           setup_vp_ref="$GITHUB_SHA"
           suite=required
           vite_plus_version=latest
+          report_pr_number=""
           skip_reason=""
 
           resolve_fork_request() {
@@ -126,6 +133,7 @@ jobs:
             should_run=true
             setup_vp_ref="$REQUEST_HEAD_SHA"
             suite=full
+            report_pr_number="$pr_number"
           }
 
           if [ "$EVENT_NAME" = "pull_request" ]; then
@@ -134,6 +142,7 @@ jobs:
               skip_reason='A maintainer with write access can review this fork PR and add the run-e2e label to test its current commit. New commits require removing and re-adding the label. The merge queue also tests the reviewed merge commit.'
             else
               setup_vp_ref="$PR_HEAD_SHA"
+              report_pr_number="$PR_NUMBER"
               while IFS= read -r changed_path; do
                 case "$changed_path" in
                   gitlab/* | src/gitlab/* | src/ci/* | dist/gitlab/* | .github/workflows/gitlab-e2e.yml | vite.config.ts | package.json | pnpm-lock.yaml | pnpm-workspace.yaml)
@@ -163,6 +172,7 @@ jobs:
             echo "setup_vp_ref=$setup_vp_ref"
             echo "suite=$suite"
             echo "vite_plus_version=$vite_plus_version"
+            echo "pr_number=$report_pr_number"
           } >> "$GITHUB_OUTPUT"
 
           if [ "$should_run" = "false" ]; then
@@ -272,3 +282,90 @@ jobs:
           fi
           echo "::error::GitLab pipeline finished with status $final_status."
           exit 1
+
+  report-result:
+    name: Report GitLab E2E result
+    needs: gitlab-e2e
+    if: always() && needs.gitlab-e2e.outputs.pr_number != ''
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    concurrency:
+      group: gitlab-e2e-comment-${{ needs.gitlab-e2e.outputs.pr_number }}
+      cancel-in-progress: false
+    steps:
+      - name: Update PR comment
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_NUMBER: ${{ needs.gitlab-e2e.outputs.pr_number }}
+          SETUP_VP_REF: ${{ needs.gitlab-e2e.outputs.setup_vp_ref }}
+          TEST_SUITE: ${{ needs.gitlab-e2e.outputs.suite }}
+          VITE_PLUS_VERSION: ${{ needs.gitlab-e2e.outputs.vite_plus_version }}
+          PIPELINE_URL: ${{ needs.gitlab-e2e.outputs.pipeline_url }}
+          RESULT: ${{ needs.gitlab-e2e.result }}
+        with:
+          script: |
+            const { PR_NUMBER, SETUP_VP_REF, TEST_SUITE, VITE_PLUS_VERSION, PIPELINE_URL, RESULT } = process.env;
+            const issue = { ...context.repo, issue_number: Number(PR_NUMBER) };
+            const { data: pr } = await github.rest.pulls.get({ ...context.repo, pull_number: issue.issue_number });
+            if (pr.head.sha !== SETUP_VP_REF) {
+              core.info('The PR head changed; skip this result.');
+              return;
+            }
+
+            const marker = '<!-- setup-vp-gitlab-e2e -->';
+            const comments = await github.paginate(github.rest.issues.listComments, { ...issue, per_page: 100 });
+            let previous;
+            for (const comment of comments) {
+              if (!comment.body?.startsWith(marker)) continue;
+              if (comment.user?.login === 'github-actions[bot]') {
+                previous = comment;
+                break;
+              }
+              // Reuse a result posted by a maintainer, including before automation was added.
+              if (!comment.user) continue;
+              let permission;
+              try {
+                const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                  ...context.repo, username: comment.user.login,
+                });
+                permission = data.permission;
+              } catch (error) {
+                if (error.status === 404) continue;
+                throw error;
+              }
+              if (permission === 'admin' || permission === 'write') {
+                previous = comment;
+                break;
+              }
+            }
+
+            const attempt = Number(process.env.GITHUB_RUN_ATTEMPT);
+            const previousRun = previous?.body.match(/<!-- setup-vp-gitlab-e2e-run:(\d+):(\d+) -->/);
+            if (previousRun && (Number(previousRun[1]) > context.runId ||
+              (Number(previousRun[1]) === context.runId && Number(previousRun[2]) > attempt))) {
+              core.info('A newer run already reported its result.');
+              return;
+            }
+
+            let title;
+            if (RESULT === 'success') title = '✅ GitLab E2E passed';
+            else if (RESULT === 'cancelled') title = '⚠️ GitLab E2E run cancelled';
+            else if (!PIPELINE_URL) title = '❌ GitLab E2E could not start';
+            else title = '❌ GitLab E2E did not complete successfully';
+
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}/attempts/${attempt}`;
+            const links = [PIPELINE_URL && `[GitLab pipeline](${PIPELINE_URL})`, `[GitHub Actions run](${runUrl})`].filter(Boolean);
+            const body = [
+              marker,
+              `<!-- setup-vp-gitlab-e2e-run:${context.runId}:${attempt} -->`,
+              '', `### ${title}`, '',
+              `Commit: \`${SETUP_VP_REF}\`  `,
+              `Suite: \`${TEST_SUITE}\` · Vite+ version: \`${VITE_PLUS_VERSION}\``,
+              '', links.join(' · '),
+            ].join('\n');
+            if (previous) {
+              await github.rest.issues.updateComment({ ...context.repo, comment_id: previous.id, body });
+            } else {
+              await github.rest.issues.createComment({ ...issue, body });
+            }

--- a/README.md
+++ b/README.md
@@ -693,7 +693,7 @@ vp install
 
 After reviewing the commit, a maintainer with write access can add `run-e2e` to run the full GitLab suite. Approve the Actions run if prompted.
 
-For new commits, review the changes and remove and re-add `run-e2e`. Results and the GitLab pipeline link appear in the GitLab E2E workflow summary.
+For new commits, review the changes and remove and re-add `run-e2e`. Results and the GitLab pipeline link appear in a PR comment, which is updated after each run.
 
 ### Releasing
 

--- a/src/gitlab/report-result.test.ts
+++ b/src/gitlab/report-result.test.ts
@@ -1,0 +1,179 @@
+import { readFileSync } from "node:fs";
+import { runInNewContext } from "node:vm";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { parse as parseYaml } from "yaml";
+
+const workflow = parseYaml(
+  readFileSync(new URL("../../.github/workflows/gitlab-e2e.yml", import.meta.url), "utf8"),
+);
+const report = workflow.jobs["report-result"];
+const headSha = "a".repeat(40);
+const marker = "<!-- setup-vp-gitlab-e2e -->";
+const pipelineUrl = "https://gitlab.com/example/project/-/pipelines/42";
+
+function comment(login = "github-actions[bot]", runId = 100, attempt = 1) {
+  return {
+    id: 42,
+    user: { login },
+    body: `${marker}\n<!-- setup-vp-gitlab-e2e-run:${runId}:${attempt} -->\nPrevious result`,
+  };
+}
+
+function reporter(env: Record<string, string> = {}) {
+  const issues = {
+    listComments: vi.fn(),
+    createComment: vi.fn(),
+    updateComment: vi.fn(),
+  };
+  const github = {
+    paginate: vi.fn().mockResolvedValue([]),
+    rest: {
+      issues,
+      pulls: { get: vi.fn().mockResolvedValue({ data: { head: { sha: headSha } } }) },
+      repos: {
+        getCollaboratorPermissionLevel: vi
+          .fn()
+          .mockResolvedValue({ data: { permission: "write" } }),
+      },
+    },
+  };
+  return {
+    github,
+    issues,
+    run: () =>
+      runInNewContext(`(async () => { ${report.steps[0].with.script} })()`, {
+        github,
+        context: {
+          repo: { owner: "upstream", repo: "setup-vp" },
+          runId: 200,
+          serverUrl: "https://github.com",
+        },
+        core: { info: vi.fn() },
+        process: {
+          env: {
+            PR_NUMBER: "123",
+            SETUP_VP_REF: headSha,
+            TEST_SUITE: "full",
+            VITE_PLUS_VERSION: "latest",
+            PIPELINE_URL: pipelineUrl,
+            RESULT: "success",
+            GITHUB_RUN_ATTEMPT: "1",
+            ...env,
+          },
+        },
+      }),
+  };
+}
+
+describe("GitLab E2E result comment", () => {
+  it("isolates comment writes in an API-only job for validated PRs, including failed runs", () => {
+    expect(report.needs).toBe("gitlab-e2e");
+    expect(report.if).toBe("always() && needs.gitlab-e2e.outputs.pr_number != ''");
+    expect(report.permissions).toEqual({ "pull-requests": "write" });
+    expect(report.concurrency).toEqual({
+      group: "gitlab-e2e-comment-${{ needs.gitlab-e2e.outputs.pr_number }}",
+      "cancel-in-progress": false,
+    });
+    expect(report.steps).toHaveLength(1);
+    expect(report.steps[0].uses).toMatch(/^actions\/github-script@[a-f0-9]{40}$/);
+    expect(report.steps[0].with.script).not.toContain("${{");
+  });
+
+  it("creates a result with the tested commit and pipeline and run links", async () => {
+    const { run, github, issues } = reporter();
+    await run();
+    expect(github.paginate).toHaveBeenCalledWith(issues.listComments, {
+      owner: "upstream",
+      repo: "setup-vp",
+      issue_number: 123,
+      per_page: 100,
+    });
+    expect(issues.createComment).toHaveBeenCalledOnce();
+    const body = issues.createComment.mock.calls[0][0].body;
+    expect(body).toContain("### ✅ GitLab E2E passed");
+    expect(body).toContain(`Commit: \`${headSha}\``);
+    expect(body).toContain("Suite: `full` · Vite+ version: `latest`");
+    expect(body).toContain(`[GitLab pipeline](${pipelineUrl})`);
+    expect(body).toContain("https://github.com/upstream/setup-vp/actions/runs/200/attempts/1");
+    expect(body).toContain("<!-- setup-vp-gitlab-e2e-run:200:1 -->");
+    expect(issues.updateComment).not.toHaveBeenCalled();
+  });
+
+  it.each(["github-actions[bot]", "maintainer"])(
+    "reuses a result posted by %s on a rerun",
+    async (login) => {
+      const { run, github, issues } = reporter({ GITHUB_RUN_ATTEMPT: "2" });
+      github.paginate.mockResolvedValue([comment(login, 200)]);
+      await run();
+      expect(issues.updateComment).toHaveBeenCalledWith({
+        owner: "upstream",
+        repo: "setup-vp",
+        comment_id: 42,
+        body: expect.stringContaining("<!-- setup-vp-gitlab-e2e-run:200:2 -->"),
+      });
+      expect(issues.createComment).not.toHaveBeenCalled();
+      if (login === "maintainer") {
+        expect(github.rest.repos.getCollaboratorPermissionLevel).toHaveBeenCalledWith({
+          owner: "upstream",
+          repo: "setup-vp",
+          username: "maintainer",
+        });
+      } else {
+        expect(github.rest.repos.getCollaboratorPermissionLevel).not.toHaveBeenCalled();
+      }
+    },
+  );
+
+  it.each([
+    ["failure", pipelineUrl, "❌ GitLab E2E did not complete successfully"],
+    ["failure", "", "❌ GitLab E2E could not start"],
+    ["cancelled", pipelineUrl, "⚠️ GitLab E2E run cancelled"],
+  ])("updates the result for %s with pipeline URL '%s'", async (result, url, title) => {
+    const { run, github, issues } = reporter({ RESULT: result, PIPELINE_URL: url });
+    github.paginate.mockResolvedValue([comment()]);
+    await run();
+    const body = issues.updateComment.mock.calls[0][0].body;
+    expect(body).toContain(`### ${title}`);
+    expect(body.includes("[GitLab pipeline]")).toBe(Boolean(url));
+    expect(issues.createComment).not.toHaveBeenCalled();
+  });
+
+  it("does not report a result after the PR head changes", async () => {
+    const { run, github, issues } = reporter();
+    github.rest.pulls.get.mockResolvedValue({ data: { head: { sha: "b".repeat(40) } } });
+    await run();
+    expect(github.paginate).not.toHaveBeenCalled();
+    expect(issues.createComment).not.toHaveBeenCalled();
+    expect(issues.updateComment).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [201, 1],
+    [200, 2],
+  ])("does not overwrite a newer run %s attempt %s", async (runId, attempt) => {
+    const { run, github, issues } = reporter();
+    github.paginate.mockResolvedValue([comment("github-actions[bot]", runId, attempt)]);
+    await run();
+    expect(issues.createComment).not.toHaveBeenCalled();
+    expect(issues.updateComment).not.toHaveBeenCalled();
+  });
+
+  it("ignores copied markers from users without write access", async () => {
+    const { run, github, issues } = reporter();
+    github.paginate.mockResolvedValue([comment("contributor", 999), comment()]);
+    github.rest.repos.getCollaboratorPermissionLevel.mockResolvedValue({
+      data: { permission: "read" },
+    });
+    await run();
+    expect(issues.updateComment).toHaveBeenCalledOnce();
+    expect(issues.createComment).not.toHaveBeenCalled();
+  });
+
+  it("fails without creating a duplicate when the comment API is unavailable", async () => {
+    const { run, github, issues } = reporter();
+    github.paginate.mockRejectedValue(new Error("API unavailable"));
+    await expect(run()).rejects.toThrow("API unavailable");
+    expect(issues.createComment).not.toHaveBeenCalled();
+    expect(issues.updateComment).not.toHaveBeenCalled();
+  });
+});

--- a/src/gitlab/workflow.test.ts
+++ b/src/gitlab/workflow.test.ts
@@ -152,6 +152,7 @@ describe("GitLab E2E workflow", () => {
         setup_vp_ref: headSha,
         suite: "full",
         vite_plus_version: "latest",
+        pr_number: "123",
       });
       expect(result.calls).toContain("collaborators/reviewer/permission");
       expect(result.calls).not.toContain("/files");
@@ -189,6 +190,7 @@ describe("GitLab E2E workflow", () => {
     const result = resolveParameters({ MOCK_PR: JSON.stringify({ ...approvedPr, ...changes }) });
     expect(result.status, result.stderr).toBe(0);
     expect(result.outputs.should_run).toBe("false");
+    expect(result.outputs.pr_number).toBe("");
     expect(result.summary).toContain("This approval is stale");
   });
 
@@ -204,6 +206,7 @@ describe("GitLab E2E workflow", () => {
     const result = resolveParameters(env);
     expect(result.status, result.stderr).toBe(0);
     expect(result.outputs.should_run).toBe("false");
+    expect(result.outputs.pr_number).toBe("");
     expect(result.calls).toBe("");
   });
 
@@ -226,6 +229,7 @@ describe("GitLab E2E workflow", () => {
     const result = resolveParameters({ EVENT_NAME: "pull_request" });
     expect(result.status, result.stderr).toBe(0);
     expect(result.outputs.should_run).toBe("false");
+    expect(result.outputs.pr_number).toBe("");
     expect(result.calls).toBe("");
     expect(result.summary).toContain("add the run-e2e label");
   });
@@ -240,7 +244,12 @@ describe("GitLab E2E workflow", () => {
       MOCK_CHANGED_FILES: files,
     });
     expect(result.status, result.stderr).toBe(0);
-    expect(result.outputs).toMatchObject({ should_run: "true", setup_vp_ref: headSha, suite });
+    expect(result.outputs).toMatchObject({
+      should_run: "true",
+      setup_vp_ref: headSha,
+      suite,
+      pr_number: "123",
+    });
     expect(result.calls).not.toContain("/permission");
   });
 
@@ -275,6 +284,7 @@ describe("GitLab E2E workflow", () => {
       setup_vp_ref: ref,
       suite,
       vite_plus_version: version,
+      pr_number: "",
     });
     expect(result.calls).toBe("");
   });


### PR DESCRIPTION
GitLab E2E results currently appear only in the workflow summary, so PR authors must open Actions to find them.

The workflow now posts the result, tested commit, and pipeline link in a PR comment. Each later run updates the same comment. Older runs cannot overwrite newer results.
